### PR TITLE
Add Decision Environment role and module

### DIFF
--- a/changelogs/fragments/decision_environment.yml
+++ b/changelogs/fragments/decision_environment.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Added decision environment module
+  - Added decision environment role
+...

--- a/plugins/modules/decision_environment.py
+++ b/plugins/modules/decision_environment.py
@@ -19,7 +19,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: decision_environment
-author: "Derek Waters (dwaters@redhat.com)"
+author: "Derek Waters (@derekwaters)"
 short_description: Manage a Decision Environment in EDA Controller
 description:
     - Create, update and delete decision environments in EDA Controller

--- a/plugins/modules/decision_environment.py
+++ b/plugins/modules/decision_environment.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2024, Derek Waters <dwaters@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: decision_environment
+author: "Derek Waters (dwaters@redhat.com)"
+short_description: Manage a Decision Environment in EDA Controller
+description:
+    - Create, update and delete decision environments in EDA Controller
+options:
+    name:
+      description:
+        - The name of the decision environment.
+      required: True
+      type: str
+    new_name:
+      description:
+        - Setting this option will change the existing name (looked up via the name field).
+      type: str
+    description:
+      description:
+        - The description of the decision environment.
+      required: False
+      type: str
+    image_url:
+      description:
+        - The full image location to use for the decision environment, including the container registry, image name, and version tag.
+      required: True
+      type: str
+    credential:
+      description:
+        - The token needed to access the container registry, if required.
+      required: False
+      type: str
+    state:
+      description:
+        - Desired state of the resource.
+      choices: ["present", "absent"]
+      default: "present"
+      type: str
+
+extends_documentation_fragment: infra.eda_configuration.auth
+"""
+
+
+EXAMPLES = """
+- name: Create eda decision environment
+  infra.eda_configuration.decision_environment:
+    name: my_de
+    description: my awesome decision environment
+    image_url: my-container_registry/ansible/de-minimal-8:latest
+    credential: registry_access_token
+    state: present
+    eda_host: eda.example.com
+    eda_username: admin
+    eda_password: Sup3r53cr3t
+
+"""
+
+from ..module_utils.eda_module import EDAModule
+
+
+def main():
+    # Any additional arguments that are not fields of the item can be added here
+    argument_spec = dict(
+        name=dict(required=True),
+        new_name=dict(),
+        description=dict(),
+        image_url=dict(required=True),
+        credential=dict(),
+        state=dict(choices=["present", "absent"], default="present"),
+    )
+
+    # Create a module for ourselves
+    module = EDAModule(argument_spec=argument_spec)
+
+    # Extract our parameters
+    name = module.params.get("name")
+    new_name = module.params.get("new_name")
+    state = module.params.get("state")
+
+    new_fields = {}
+
+    # Attempt to look up an existing item based on the provided data
+    existing_item = module.get_one("decision-environments", name_or_id=name, key="req_url")
+
+    if state == "absent":
+        # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
+        module.delete_if_needed(existing_item, key="req_url")
+
+    # Create the data that gets sent for create and update
+    # Remove these two comments for final
+    # Check that Links and groups works with this.
+    new_fields["name"] = new_name if new_name else (module.get_item_name(existing_item) if existing_item else name)
+    for field_name in (
+        "description",
+        "image_url",
+    ):
+        field_val = module.params.get(field_name)
+        if field_val is not None:
+            new_fields[field_name] = field_val
+
+    if module.params.get("credential") is not None:
+        new_fields["credential_id"] = module.resolve_name_to_id("credentials", module.params.get("credential"))
+
+    # If the state was present and we can let the module build or update the existing item, this will return on its own
+    module.create_or_update_if_needed(
+        existing_item,
+        new_fields,
+        endpoint="decision-environments",
+        item_type="decision-environments",
+        key="req_url",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/decision_environment/README.md
+++ b/roles/decision_environment/README.md
@@ -1,0 +1,103 @@
+# infra.eda_configuration.decision_environment
+
+## Description
+
+An Ansible Role to create Decision Environments in EDA Controller.
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---:|:---:|:---:|:---:|:---:|
+|`eda_host`|""|yes|URL to the EDA Controller (alias: `eda_hostname`)|127.0.0.1|
+|`eda_username`|""|yes|Admin User on the EDA Controller ||
+|`eda_password`|""|yes|EDA Controller Admin User's password on the EDA Controller Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
+|`eda_validate_certs`|`False`|no|Whether or not to validate the Ansible EDA Controller Server's SSL certificate.||
+|`eda_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the EDA Controller host.||
+|`eda_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
+|`eda_decision_environments`|`see below`|yes|Data structure describing your decision environments, described below.||
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to False as normally the add project task does not include sensitive information.
+eda_configuration_project_secure_logging defaults to the value of eda_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of EDA Controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_project_secure_logging`|`False`|no|Whether or not to include the sensitive Project role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`eda_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`eda_configuration_project_async_retries`|`eda_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`eda_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`eda_configuration_project_async_delay`|`eda_configuration_async_delay`|no|This sets the delay between retries for the role.|
+
+## Data Structure
+
+### Decision Environment Variables
+
+|Variable Name|Default Value|Required|Type|Description|
+|:---:|:---:|:---:|:---:|:---:|
+|`name`|""|yes|str|Decision Environment name. Must be lower case containing only alphanumeric characters and underscores.|
+|`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.)|
+|`description`|""|yes|str|Description to use for the Project.|
+|`image_url`|""|yes|str|A URL to a a container image to use for the decision environment.|
+|`credential`|""|no|str|The credential used to access the container registry holding the image.|
+|`state`|`present`|no|str|Desired state of the decision environment.|
+
+### Standard Decision Environment Data Structure
+
+#### Yaml Example
+
+```yaml
+---
+eda_decision_environments:
+  - name: my_default_de
+    description: my default decision environment
+    image_url: "image_registry.example.com/default-de:latest"
+    credential: my_credential
+```
+
+## Playbook Examples
+
+### Standard Role Usage
+
+```yaml
+---
+- name: Add decision environment to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # eda_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - ../../decision_environment
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/eda_configuration#licensing)
+
+## Author
+
+[Derek Waters](https://github.com/derekwaters/)

--- a/roles/decision_environment/defaults/main.yml
+++ b/roles/decision_environment/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+eda_decision_environments: []
+
+eda_configuration_decision_environment_secure_logging: "{{ eda_configuration_secure_logging | default(false) }}"
+eda_configuration_decision_environment_async_retries: "{{ eda_configuration_async_retries | default(50) }}"
+eda_configuration_decision_environment_async_delay: "{{ eda_configuration_async_delay | default(1) }}"
+eda_configuration_async_dir: null
+...

--- a/roles/decision_environment/meta/argument_specs.yml
+++ b/roles/decision_environment/meta/argument_specs.yml
@@ -1,0 +1,70 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create decision environments in EDA controller.
+    options:
+      eda_decision_environments:
+        default: []
+        required: false
+        description: Data structure describing your decision environments to manage.
+        type: list
+        elements: dict
+
+      # Async variables
+      eda_configuration_decision_environment_async_retries:
+        default: "{{ eda_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      eda_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      eda_configuration_decision_environment_async_delay:
+        default: "{{ eda_configuration_async_delay | default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      eda_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      eda_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      eda_configuration_decision_environment_secure_logging:
+        default: "{{ eda_configuration_secure_logging | default(false) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive role tasks in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      eda_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      eda_host:
+        required: false
+        description: URL to the EDA Controller Server.
+        type: str
+      eda_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the EDA Controller Server's SSL certificate.
+        type: str
+      eda_request_timeout:
+        default: 10
+        required: false
+        description: Specify the timeout Ansible should use in requests to the EDA Controller host.
+        type: float
+      eda_username:
+        required: false
+        description: User for authentication on EDA Controller
+        type: str
+      eda_password:
+        required: false
+        description: User's password For EDA Controller
+        type: str
+...

--- a/roles/decision_environment/meta/main.yml
+++ b/roles/decision_environment/meta/main.yml
@@ -1,0 +1,42 @@
+---
+galaxy_info:
+  role_name: "decision_environment"
+  author: "Derek Waters"
+  description: "An Ansible Role to create a decision environment in EDA Controller."
+  company: "Red Hat"
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: "GPLv3+"
+
+  min_ansible_version: "2.9"
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  platforms:
+    - name: "EL"
+      versions:
+        - "all"
+
+  galaxy_tags:
+    - "edacontroller"
+    - "eda"
+    - "configuration"
+    - "decisionenvironment"
+    - "decisionenvironments"
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+...

--- a/roles/decision_environment/tasks/main.yml
+++ b/roles/decision_environment/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+
+# Create EDA Controller Decision Environment
+- name: Add EDA Controller decision environment
+  decision_environment:
+    name:             "{{ __de_item.name }}"
+    new_name:         "{{ __de_item.new_name | default(omit) }}"
+    description:      "{{ __de_item.description | default(omit) }}"
+    image_url:        "{{ __de_item.image_url | default(omit) }}"
+    credential:       "{{ __de_item.credential | default(omit) }}"
+    state:            "{{ __de_item.state | default(eda_state | default('present')) }}"
+    eda_host:         "{{ eda_host | default(eda_hostname) }}"
+    eda_username:     "{{ eda_username | default(omit) }}"
+    eda_password:     "{{ eda_password | default(omit) }}"
+    validate_certs:   "{{ eda_validate_certs | default(omit) }}"
+    request_timeout:  "{{ eda_request_timeout | default(omit) }}"
+  loop: "{{ eda_decision_environments }}"
+  loop_control:
+    loop_var: "__de_item"
+  no_log: "{{ eda_configuration_decision_environment_secure_logging }}"
+  async: 1000
+  poll: 0
+  register: __decision_environments_job_async
+  changed_when: not __decision_environments_job_async.changed
+  vars:
+    ansible_async_dir: '{{ eda_configuration_async_dir }}'
+
+- name: "Create decision_environment | Wait for finish the decision_environment creation"
+  ansible.builtin.async_status:
+    jid: "{{ __decision_environments_job_async_result_item.ansible_job_id }}"
+  register: __decision_environments_job_async_result
+  until: __decision_environments_job_async_result.finished
+  retries: "{{ eda_configuration_decision_environment_async_retries }}"
+  delay: "{{ eda_configuration_decision_environment_async_delay }}"
+  loop: "{{ __decision_environments_job_async.results }}"
+  loop_control:
+    loop_var: __decision_environments_job_async_result_item
+  when: __decision_environments_job_async_result_item.ansible_job_id is defined
+  no_log: "{{ eda_configuration_decision_environment_secure_logging }}"
+  vars:
+    ansible_async_dir: '{{ eda_configuration_async_dir }}'
+...

--- a/roles/decision_environment/tests/test.yml
+++ b/roles/decision_environment/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add decision environment to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # eda_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - ../../decision_environment
+...

--- a/roles/decision_environment/tests/vars/decision_environments.yml
+++ b/roles/decision_environment/tests/vars/decision_environments.yml
@@ -1,0 +1,7 @@
+---
+eda_decision_environments:
+  - name: my_de
+    description: my awesome decision environment
+    image_url: registry.redhat.io/ansible-automation-platform-24/de-supported-rhel8
+    credential: test_token
+...

--- a/tests/playbooks/eda_configs/eda_decision_environments.yml
+++ b/tests/playbooks/eda_configs/eda_decision_environments.yml
@@ -1,0 +1,7 @@
+---
+eda_decision_environments:
+  - name: my_de
+    description: my awesome decision environment
+    image_url: registry.redhat.io/ansible-automation-platform-24/de-supported-rhel8
+    credential: test_token
+...

--- a/tests/playbooks/eda_configs/eda_decision_environments.yml
+++ b/tests/playbooks/eda_configs/eda_decision_environments.yml
@@ -3,5 +3,5 @@ eda_decision_environments:
   - name: my_de
     description: my awesome decision environment
     image_url: registry.redhat.io/ansible-automation-platform-24/de-supported-rhel8
-    credential: test_token
+    credential: my_github_user
 ...

--- a/tests/playbooks/testing_collections_playbook.yml
+++ b/tests/playbooks/testing_collections_playbook.yml
@@ -35,4 +35,8 @@
     - name: Create credential
       ansible.builtin.include_role:
         name: credential
+
+    - name: Create decision environment
+      ansible.builtin.include_role:
+        name: decision_environment
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR implements the decision_environment module and role to allow users to define Ansible EDA Decision Environment objects in Ansible playbooks.

# How should this be tested?

Testing of the credential collection is included in the tests/playbooks/testing_collections_playbook.yml playbook. This test will create a single decision environment in EDA using a standard RedHat registry de-supported-rhel8 image, using the dummy credential created earlier in the test playbook.

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
https://github.com/redhat-cop/eda_configuration/issues/12
resolves #[12]

# Other Relevant info, PRs, etc
