### PR TITLE
Add rulebook_activation module and role

### DIFF
--- a/changelogs/fragments/activations.yml
+++ b/changelogs/fragments/activations.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Added rulebook_activation module
+  - Added rulebook_activation role
+...

--- a/changelogs/fragments/activations.yml
+++ b/changelogs/fragments/activations.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+major_changes:
   - Added rulebook_activation module
   - Added rulebook_activation role
 ...

--- a/changelogs/fragments/credential.yml
+++ b/changelogs/fragments/credential.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+major_changes:
   - Added credential module
   - Added credential role
 ...

--- a/changelogs/fragments/decision_environment.yml
+++ b/changelogs/fragments/decision_environment.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+major_changes:
   - Added decision environment module
   - Added decision environment role
 ...

--- a/changelogs/fragments/project.yml
+++ b/changelogs/fragments/project.yml
@@ -1,5 +1,5 @@
 ---
-minor_changes:
+major_changes:
   - Added project module
   - Added project role
   - Added project_sync module

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.14.0'
 ...

--- a/plugins/module_utils/eda_module.py
+++ b/plugins/module_utils/eda_module.py
@@ -569,8 +569,6 @@ class EDAModule(AnsibleModule):
         if not endpoint:
             self.fail_json(msg="Unable to create new {0} due to missing endpoint".format(item_type))
 
-        item_url = None
-
         # We have to rely on item_type being passed in since we don't have an existing item that declares its type
         # We will pull the item_name out from the new_item, if it exists
 
@@ -580,11 +578,11 @@ class EDAModule(AnsibleModule):
             self.json_output["changed"] = True
         else:
             if "json" in response and "__all__" in response["json"]:
-                self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["json"]["__all__"][0]))
+                self.fail_json(msg="Unable to create {0}: {1}".format(item_type, response["json"]["__all__"][0]))
             elif "json" in response:
-                self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["json"]))
+                self.fail_json(msg="Unable to create {0}: {1}".format(item_type, response["json"]))
             else:
-                self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["status_code"]))
+                self.fail_json(msg="Unable to create {0}: {1}".format(item_type, response["status_code"]))
 
         # If we have an on_create method and we actually changed something we can call on_create
         if on_create is not None and self.json_output["changed"]:
@@ -761,8 +759,8 @@ class EDAModule(AnsibleModule):
     def get_exactly_one(self, endpoint, name_or_id=None, **kwargs):
         return self.get_one(endpoint, name_or_id=name_or_id, allow_none=False, **kwargs)
 
-    def resolve_name_to_id(self, endpoint, name_or_id, **kwargs):
-        return self.get_exactly_one(endpoint, name_or_id, **kwargs)["id"]
+    def resolve_name_to_id(self, endpoint, name_or_id, data):
+        return self.get_exactly_one(endpoint, name_or_id, **{"data": data})["id"]
 
     def objects_could_be_different(self, old, new, field_set=None, warning=False):
         if field_set is None:
@@ -812,7 +810,7 @@ class EDAModule(AnsibleModule):
     ):
 
         if not endpoint:
-            self.fail_json(msg="Unable to trigger action due to missing endpoint".format(item_type))
+            self.fail_json(msg="Unable to trigger action due to missing endpoint")
 
         response = self.post_endpoint(endpoint, **{"data": data})
 

--- a/plugins/module_utils/eda_module.py
+++ b/plugins/module_utils/eda_module.py
@@ -313,6 +313,18 @@ class EDAModule(AnsibleModule):
 
         return self.existing_item_add_url(response["json"]["results"][0], endpoint, key=key)
 
+    def get_by_id(self, endpoint, id, **kwargs):
+        new_kwargs = kwargs.copy()
+
+        response = self.get_endpoint("{endpoint}/{id}".format(endpoint=endpoint, id=id), **new_kwargs)
+        if response["status_code"] != 200:
+            fail_msg = "Got a {0} response when trying to get id:{1} from {2}".format(response["status_code"], id, endpoint)
+            if "detail" in response.get("json", {}):
+                fail_msg += ", detail: {0}".format(response["json"]["detail"])
+            self.fail_json(msg=fail_msg)
+
+        return response["json"]
+
     def get_only(self, endpoint, name_or_id=None, allow_none=True, key="url", **kwargs):
         new_kwargs = kwargs.copy()
         if name_or_id:
@@ -537,6 +549,52 @@ class EDAModule(AnsibleModule):
             last_data = response["json"]
             return last_data
 
+    def create_no_name(
+        self,
+        new_item,
+        endpoint,
+        on_create=None,
+        auto_exit=False,
+        item_type="unknown",
+    ):
+
+        # This will exit from the module on its own
+        # If the method successfully creates an item and on_create param is defined,
+        #    the on_create parameter will be called as a method pasing in this object and the json from the response
+        # This will return one of two things:
+        #    1. None if the existing_item is already defined (so no create needs to happen)
+        #    2. The response from EDA Controller from calling the patch on the endpont. It's up to you to process the response and exit from the module
+        # Note: common error codes from the EDA Controller API can cause the module to fail
+
+        if not endpoint:
+            self.fail_json(msg="Unable to create new {0} due to missing endpoint".format(item_type))
+
+        item_url = None
+
+        # We have to rely on item_type being passed in since we don't have an existing item that declares its type
+        # We will pull the item_name out from the new_item, if it exists
+
+        response = self.post_endpoint(endpoint, **{"data": new_item})
+
+        if response["status_code"] in [200, 201]:
+            self.json_output["changed"] = True
+        else:
+            if "json" in response and "__all__" in response["json"]:
+                self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["json"]["__all__"][0]))
+            elif "json" in response:
+                self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["json"]))
+            else:
+                self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["status_code"]))
+
+        # If we have an on_create method and we actually changed something we can call on_create
+        if on_create is not None and self.json_output["changed"]:
+            on_create(self, response["json"])
+        elif auto_exit:
+            self.exit_json(**self.json_output)
+        else:
+            last_data = response["json"]
+            return last_data
+
     def update_if_needed(
         self,
         existing_item,
@@ -703,8 +761,8 @@ class EDAModule(AnsibleModule):
     def get_exactly_one(self, endpoint, name_or_id=None, **kwargs):
         return self.get_one(endpoint, name_or_id=name_or_id, allow_none=False, **kwargs)
 
-    def resolve_name_to_id(self, endpoint, name_or_id):
-        return self.get_exactly_one(endpoint, name_or_id)["id"]
+    def resolve_name_to_id(self, endpoint, name_or_id, **kwargs):
+        return self.get_exactly_one(endpoint, name_or_id, **kwargs)["id"]
 
     def objects_could_be_different(self, old, new, field_set=None, warning=False):
         if field_set is None:
@@ -745,6 +803,34 @@ class EDAModule(AnsibleModule):
 
         self.json_output["changed"] = True
         self.exit_json(**self.json_output)
+
+    def trigger_post_action(
+        self,
+        endpoint,
+        auto_exit=False,
+        data=None,
+    ):
+
+        if not endpoint:
+            self.fail_json(msg="Unable to trigger action due to missing endpoint".format(item_type))
+
+        response = self.post_endpoint(endpoint, **{"data": data})
+
+        if response["status_code"] in [200, 201, 204]:
+            self.json_output["changed"] = True
+        else:
+            if "json" in response and "__all__" in response["json"]:
+                self.fail_json(msg="Unable to trigger {0}: {1}".format(endpoint, response["json"]["__all__"][0]))
+            elif "json" in response:
+                self.fail_json(msg="Unable to trigger {0}: {1}".format(endpoint, response["json"]))
+            else:
+                self.fail_json(msg="Unable to trigger {0}: {1}".format(endpoint, response["status_code"]))
+
+        if auto_exit:
+            self.exit_json(**self.json_output)
+        else:
+            last_data = response["json"]
+            return last_data
 
     @staticmethod
     def _resolve_path(path):

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -121,7 +121,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = EDAModule(argument_spec=argument_spec, required_if=[("state", "present",("rulebook", "decision_environment"))])
+    module = EDAModule(argument_spec=argument_spec, required_if=[("state", "present", ("rulebook", "decision_environment"))])
 
     # Extract our parameters
     name = module.params.get("name")
@@ -162,7 +162,10 @@ def main():
 
     if (module.params.get("project") is not None) and (module.params.get("rulebook") is not None):
         new_fields["project_id"] = module.resolve_name_to_id("projects", module.params.get("project"))
-        new_fields["rulebook_id"] = module.resolve_name_to_id("rulebooks", module.params.get("rulebook"), **{"data": {"project_id": int(new_fields["project_id"])}})
+        new_fields["rulebook_id"] = module.resolve_name_to_id("rulebooks",
+                                                              module.params.get("rulebook"),
+                                                              data={"project_id": int(new_fields["project_id"])},
+                                                              )
     else:
         new_fields["rulebook_id"] = module.resolve_name_to_id("rulebooks", module.params.get("rulebook"))
 
@@ -180,7 +183,11 @@ def main():
                 if json.dumps(module.params.get("extra_vars")) == existing_vars["extra_var"]:
                     new_fields["extra_var_id"] = existing_item["extra_var_id"]
         else:
-            new_fields["extra_var_id"] = module.create_no_name({"extra_var": json.dumps(module.params.get("extra_vars"))}, endpoint="extra-vars", item_type="extra_vars")["id"]
+            new_fields["extra_var_id"] = module.create_no_name(
+                {"extra_var": json.dumps(module.params.get("extra_vars"))},
+                endpoint="extra-vars",
+                item_type="extra_vars"
+            )["id"]
 
     if existing_item is not None:
         # If the activation already exists, all we can do is change whether it is enabled or disabled.

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2023, Tom Page <@Tompage1994>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: rulebook_activation
+author: "Tom Page (@Tompage1994)"
+short_description: Manage a rulebook_activation in EDA Controller
+description:
+    - Create, enable, disable and delete rulebook activations in EDA Controller
+options:
+    name:
+      description:
+        - The name of the rulebook activation.
+      required: True
+      type: str
+    description:
+      description:
+        - The description of the rulebook_activation.
+      required: False
+      type: str
+    project:
+      description:
+        - The project from which the rulebook is found.
+      required: False
+      type: str
+    rulebook:
+      description:
+        - The name of the rulebook to activate.
+      required: True
+      type: str
+    decision_environment:
+      description:
+        - The decision environment to be used.
+      required: True
+      type: str
+    restart_policy:
+      description:
+        - The policy used to determine whether to restart a rulebook.
+      required: False
+      choices: ["always", "never", "on_failure"]
+      default: "always"
+      type: str
+    extra_vars:
+      description:
+        - Specify C(extra_vars) for the template.
+      required: False
+      type: dict
+    enabled:
+      description:
+        - Whether the rulebook activation is automatically enabled to run.
+      default: true
+      type: bool
+    state:
+      description:
+        - Desired state of the resource.
+      choices: ["present", "absent"]
+      default: "present"
+      type: str
+
+extends_documentation_fragment: infra.eda_configuration.auth
+"""
+
+
+EXAMPLES = """
+- name: Create eda rulebook activation
+  infra.eda_configuration.rulebook_activation:
+    name: Github Hook
+    description: Hook to listen for changes in GitHub
+    project: eda_examples
+    rulebook: git-hook-deploy-rules.yml
+    decision_environment: my_de
+    extra_vars:
+      provider: github
+      repo_url: https://github.com/ansible/ansible-rulebook.git
+    enabled: true
+    state: present
+"""
+
+from ..module_utils.eda_module import EDAModule
+import json
+
+
+def main():
+    # Any additional arguments that are not fields of the item can be added here
+    argument_spec = dict(
+        name=dict(required=True),
+        description=dict(),
+        project=dict(),
+        rulebook=dict(required=True),
+        decision_environment=dict(required=True),
+        restart_policy=dict(choices=["always", "never", "on_failure"], default="always"),
+        extra_vars=dict(type="dict"),
+        enabled=dict(type="bool", default="true"),
+        state=dict(choices=["present", "absent"], default="present"),
+    )
+
+    # Create a module for ourselves
+    module = EDAModule(argument_spec=argument_spec)
+
+    # Extract our parameters
+    name = module.params.get("name")
+    state = module.params.get("state")
+
+    new_fields = {}
+
+    # Attempt to look up an existing item based on the provided data
+    existing_item = module.get_one("activations", name_or_id=name, key="req_url")
+
+    if state == "absent":
+        # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
+        module.delete_if_needed(existing_item, key="req_url")
+
+    # Create the data that gets sent for create and update
+    # Remove these two comments for final
+    # Check that Links and groups works with this.
+    for field_name in (
+        "name",
+        "description",
+        "restart_policy",
+    ):
+        field_val = module.params.get(field_name)
+        if field_val is not None:
+            new_fields[field_name] = field_val
+
+    if module.params.get("enabled") is not None:
+        new_fields["is_enabled"] = module.params.get("enabled")
+
+    if (module.params.get("project") is not None) and (module.params.get("rulebook") is not None):
+        new_fields["project_id"] = module.resolve_name_to_id("projects", module.params.get("project"))
+        new_fields["rulebook_id"] = module.resolve_name_to_id("rulebooks", module.params.get("rulebook"), **{"data": {"project_id": int(new_fields["project_id"])}})
+    else:
+        new_fields["rulebook_id"] = module.resolve_name_to_id("rulebooks", module.params.get("rulebook"))
+
+    if module.params.get("decision_environment") is not None:
+        new_fields["decision_environment_id"] = module.resolve_name_to_id("decision-environments", module.params.get("decision_environment"))
+
+    # Create the extra_vars
+    if module.params.get("extra_vars") is not None:
+        if existing_item is not None:
+            new_fields["extra_var_id"] = -1  # Default it as something that isn't acceptable. Prove otherwise
+            if existing_item["extra_var_id"]:
+                # Check if matching existing extra_vars
+                existing_vars = module.get_by_id("extra-vars", id=existing_item["extra_var_id"])
+                # Test if the same
+                if json.dumps(module.params.get("extra_vars")) == existing_vars["extra_var"]:
+                    new_fields["extra_var_id"] = existing_item["extra_var_id"]
+        else:
+            new_fields["extra_var_id"] = module.create_no_name({"extra_var": json.dumps(module.params.get("extra_vars"))}, endpoint="extra-vars", item_type="extra_vars")["id"]
+
+    if existing_item is not None:
+        # If the activation already exists, all we can do is change whether it is enabled or disabled.
+        # The module will exit from this section
+
+        # First, fail; if trying to change anything other than being enabled
+        if ("description" in new_fields and existing_item["description"] != new_fields["description"]
+                or "restart_policy" in new_fields and existing_item["restart_policy"] != new_fields["restart_policy"]
+                or "project_id" in new_fields and existing_item["project_id"] != new_fields["project_id"]
+                or "rulebook_id" in new_fields and existing_item["rulebook_id"] != new_fields["rulebook_id"]
+                or "decision_environment_id" in new_fields and existing_item["decision_environment_id"] != new_fields["decision_environment_id"]
+                or "extra_var_id" in new_fields and existing_item["extra_var_id"] != new_fields["extra_var_id"]):
+            module.fail_json(msg="Once an activation has been created it can only be enabled, disabled or deleted. Other changes cannot be made.")
+
+        if module.params.get("enabled") is not None:
+            if module.params.get("enabled") and not existing_item["is_enabled"]:
+                module.trigger_post_action("activations/{id}/enable".format(id=existing_item["id"]), auto_exit=True)
+            elif (not module.params.get("enabled")) and existing_item["is_enabled"]:
+                module.trigger_post_action("activations/{id}/disable".format(id=existing_item["id"]), auto_exit=True)
+        module.exit_json(**module.json_output)
+
+    # If the state was present and we can let the module build or update the existing item, this will return on its own
+    module.create_if_needed(
+        existing_item,
+        new_fields,
+        endpoint="activations",
+        item_type="rulebook_activations",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/credential/meta/main.yml
+++ b/roles/credential/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   # issue_tracker_url: http://example.com/issue/tracker
   license: "GPLv3+"
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.14"
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,

--- a/roles/decision_environment/meta/main.yml
+++ b/roles/decision_environment/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   # issue_tracker_url: http://example.com/issue/tracker
   license: "GPLv3+"
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.14"
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,

--- a/roles/project/meta/main.yml
+++ b/roles/project/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   # issue_tracker_url: http://example.com/issue/tracker
   license: "GPLv3+"
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.14"
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,

--- a/roles/project_sync/meta/main.yml
+++ b/roles/project_sync/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   # issue_tracker_url: http://example.com/issue/tracker
   license: "GPLv3+"
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.14"
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,

--- a/roles/rulebook_activation/README.md
+++ b/roles/rulebook_activation/README.md
@@ -1,0 +1,112 @@
+# infra.eda_configuration.rulebook_activation
+
+## Description
+
+An Ansible Role to create rulebook activations in EDA Controller.
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---:|:---:|:---:|:---:|:---:|
+|`eda_host`|""|yes|URL to the EDA Controller (alias: `eda_hostname`)|127.0.0.1|
+|`eda_username`|""|yes|Admin User on the EDA Controller ||
+|`eda_password`|""|yes|EDA Controller Admin User's password on the EDA Controller Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
+|`eda_validate_certs`|`False`|no|Whether or not to validate the Ansible EDA Controller Server's SSL certificate.||
+|`eda_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the EDA Controller host.||
+|`eda_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
+|`eda_rulebook_activations`|`see below`|yes|Data structure describing your rulebook activations, described below.||
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to False as normally the add project task does not include sensitive information.
+eda_configuration_project_secure_logging defaults to the value of eda_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of EDA Controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_project_secure_logging`|`False`|no|Whether or not to include the sensitive Project role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`eda_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`eda_configuration_project_async_retries`|`eda_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`eda_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`eda_configuration_project_async_delay`|`eda_configuration_async_delay`|no|This sets the delay between retries for the role.|
+
+## Data Structure
+
+### Rulebook activation Variables
+
+|Variable Name|Default Value|Required|Type|Description|
+|:---:|:---:|:---:|:---:|:---:|
+|`name`|""|yes|str|Rulebook activation name. Must be lower case containing only alphanumeric characters and underscores.|
+|`description`|""|no|str|Description to use for the Activation.|
+|`project`|""|no|str|project to use for the Activation.|
+|`rulebook`|""|yes|str|rulebook to use for the Activation.|
+|`decision_environment`|""|yes|str|decision_environment to use for the Activation.|
+|`restart_policy`|"always"|no|str|restart_policy to use for the Activation, choice of ["always", "never", "on_failure"]|
+|`extra_vars`|""|no|str|extra_vars to use for the Activation.|
+|`enabled`|"true"|no|str|Whether the rulebook activation is automatically enabled to run.|
+|`state`|`present`|no|str|Desired state of the rulebook activation.|
+
+### Standard rulebook activation Data Structure
+
+#### Yaml Example
+
+```yaml
+---
+eda_rulebook_activations:
+  - name: Github Hook
+    description: Hook to listen for changes in GitHub
+    project: EDA_example
+    rulebook: git-hook-deploy-rules.yml
+    decision_environment: Automation Hub Default Decision Environment
+    extra_vars:
+      provider: github-local
+      repo_url: https://github.com/ansible/ansible-rulebook.git
+    enabled: false
+    state: present
+```
+
+## Playbook Examples
+
+### Standard Role Usage
+
+```yaml
+---
+- name: Add rulebook activation to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # eda_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - ../../rulebook_activation
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/eda_configuration#licensing)
+
+## Author
+
+[Tom Page](https://github.com/Tompage1994/)

--- a/roles/rulebook_activation/defaults/main.yml
+++ b/roles/rulebook_activation/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+eda_rulebook_activations: []
+
+eda_configuration_rulebook_activation_secure_logging: "{{ eda_configuration_secure_logging | default(false) }}"
+eda_configuration_rulebook_activation_async_retries: "{{ eda_configuration_async_retries | default(50) }}"
+eda_configuration_rulebook_activation_async_delay: "{{ eda_configuration_async_delay | default(1) }}"
+eda_configuration_async_dir: null
+...

--- a/roles/rulebook_activation/meta/argument_specs.yml
+++ b/roles/rulebook_activation/meta/argument_specs.yml
@@ -1,0 +1,70 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create rulebook activations in EDA controller.
+    options:
+      eda_rulebook_activations:
+        default: []
+        required: false
+        description: Data structure describing your rulebook activations to manage.
+        type: list
+        elements: dict
+
+      # Async variables
+      eda_configuration_rulebook_activation_async_retries:
+        default: "{{ eda_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      eda_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      eda_configuration_rulebook_activation_async_delay:
+        default: "{{ eda_configuration_async_delay | default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      eda_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      eda_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      eda_configuration_rulebook_activation_secure_logging:
+        default: "{{ eda_configuration_secure_logging | default(false) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive role tasks in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      eda_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      eda_host:
+        required: false
+        description: URL to the EDA Controller Server.
+        type: str
+      eda_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the EDA Controller Server's SSL certificate.
+        type: str
+      eda_request_timeout:
+        default: 10
+        required: false
+        description: Specify the timeout Ansible should use in requests to the EDA Controller host.
+        type: float
+      eda_username:
+        required: false
+        description: User for authentication on EDA Controller
+        type: str
+      eda_password:
+        required: false
+        description: User's password For EDA Controller
+        type: str
+...

--- a/roles/rulebook_activation/meta/main.yml
+++ b/roles/rulebook_activation/meta/main.yml
@@ -1,0 +1,44 @@
+---
+galaxy_info:
+  role_name: "rulebook_activation"
+  author: "Derek Waters"
+  description: "An Ansible Role to create a rulebook activation in EDA Controller."
+  company: "Red Hat"
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: "GPLv3+"
+
+  min_ansible_version: "2.9"
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  platforms:
+    - name: "EL"
+      versions:
+        - "all"
+
+  galaxy_tags:
+    - "edacontroller"
+    - "eda"
+    - "configuration"
+    - "rulebookactivation"
+    - "rulebookactivations"
+    - "activation"
+    - "activations"
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+...

--- a/roles/rulebook_activation/meta/main.yml
+++ b/roles/rulebook_activation/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   role_name: "rulebook_activation"
-  author: "Derek Waters"
+  author: "Tom Page"
   description: "An Ansible Role to create a rulebook activation in EDA Controller."
   company: "Red Hat"
 
@@ -10,7 +10,7 @@ galaxy_info:
   # issue_tracker_url: http://example.com/issue/tracker
   license: "GPLv3+"
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.14"
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,

--- a/roles/rulebook_activation/tasks/main.yml
+++ b/roles/rulebook_activation/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+
+# Create EDA Controller Rulebook Activation
+- name: Add EDA Controller rulebook activation
+  rulebook_activation:
+    name:                 "{{ __ra_item.name }}"
+    description:          "{{ __ra_item.description | default(omit) }}"
+    project:              "{{ __ra_item.project | default(omit) }}"
+    rulebook:             "{{ __ra_item.rulebook | default(omit) }}"
+    decision_environment: "{{ __ra_item.decision_environment | default(omit) }}"
+    restart_policy:       "{{ __ra_item.restart_policy | default(omit) }}"
+    extra_vars:           "{{ __ra_item.extra_vars | default(omit) }}"
+    enabled:              "{{ __ra_item.enabled | default(omit) }}"
+    state:                "{{ __ra_item.state | default(eda_state | default('present')) }}"
+    eda_host:             "{{ eda_host | default(eda_hostname) }}"
+    eda_username:         "{{ eda_username | default(omit) }}"
+    eda_password:         "{{ eda_password | default(omit) }}"
+    validate_certs:       "{{ eda_validate_certs | default(omit) }}"
+    request_timeout:      "{{ eda_request_timeout | default(omit) }}"
+  loop: "{{ eda_rulebook_activations }}"
+  loop_control:
+    loop_var: "__ra_item"
+  no_log: "{{ eda_configuration_rulebook_activation_secure_logging }}"
+  async: 1000
+  poll: 0
+  register: __rulebook_activations_job_async
+  changed_when: not __rulebook_activations_job_async.changed
+  vars:
+    ansible_async_dir: '{{ eda_configuration_async_dir }}'
+
+- name: "Create rulebook_activation | Wait for finish the rulebook_activation creation"
+  ansible.builtin.async_status:
+    jid: "{{ __rulebook_activations_job_async_result_item.ansible_job_id }}"
+  register: __rulebook_activations_job_async_result
+  until: __rulebook_activations_job_async_result.finished
+  retries: "{{ eda_configuration_rulebook_activation_async_retries }}"
+  delay: "{{ eda_configuration_rulebook_activation_async_delay }}"
+  loop: "{{ __rulebook_activations_job_async.results }}"
+  loop_control:
+    loop_var: __rulebook_activations_job_async_result_item
+  when: __rulebook_activations_job_async_result_item.ansible_job_id is defined
+  no_log: "{{ eda_configuration_rulebook_activation_secure_logging }}"
+  vars:
+    ansible_async_dir: '{{ eda_configuration_async_dir }}'
+...

--- a/roles/rulebook_activation/tests/test.yml
+++ b/roles/rulebook_activation/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add activations to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # eda_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - ../../rulebook_activation
+...

--- a/roles/rulebook_activation/tests/vars/rulebook_activations.yml
+++ b/roles/rulebook_activation/tests/vars/rulebook_activations.yml
@@ -1,0 +1,13 @@
+---
+eda_rulebook_activations:
+  - name: Github Hook
+    description: Hook to listen for changes in GitHub
+    project: EDA_example
+    rulebook: git-hook-deploy-rules.yml
+    decision_environment: Automation Hub Default Decision Environment
+    extra_vars:
+      provider: github-local
+      repo_url: https://github.com/ansible/ansible-rulebook.git
+    enabled: false
+    state: present
+...

--- a/tests/playbooks/eda_configs/eda_rulebook_activations.yml
+++ b/tests/playbooks/eda_configs/eda_rulebook_activations.yml
@@ -1,0 +1,13 @@
+---
+eda_rulebook_activations:
+  - name: Github Hook
+    description: Hook to listen for changes in GitHub
+    project: EDA_example
+    rulebook: git-hook-deploy-rules.yml
+    decision_environment: Automation Hub Default Decision Environment
+    extra_vars:
+      provider: github-local
+      repo_url: https://github.com/ansible/ansible-rulebook.git
+    enabled: false
+    state: present
+...

--- a/tests/playbooks/eda_configs/eda_rulebook_activations.yml
+++ b/tests/playbooks/eda_configs/eda_rulebook_activations.yml
@@ -10,4 +10,14 @@ eda_rulebook_activations:
       repo_url: https://github.com/ansible/ansible-rulebook.git
     enabled: false
     state: present
+  - name: Github Hook
+    description: Hook to listen for changes in GitHub
+    project: EDA_example
+    rulebook: git-hook-deploy-rules.yml
+    decision_environment: Automation Hub Default Decision Environment
+    extra_vars:
+      provider: github-local
+      repo_url: https://github.com/ansible/ansible-rulebook.git
+    enabled: false
+    state: restarted
 ...

--- a/tests/playbooks/testing_collections_playbook.yml
+++ b/tests/playbooks/testing_collections_playbook.yml
@@ -39,4 +39,8 @@
     - name: Create decision environment
       ansible.builtin.include_role:
         name: decision_environment
+
+    - name: Create rulebook activations
+      ansible.builtin.include_role:
+        name: decision_environment
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Adds the rulebook_activation role and module

# How should this be tested?
Eventually CI, otherwise for now something like this works:

```
- name: Create eda rulebook activation
  ansible.builtin.include_role:
    name: infra.eda_configuration.rulebook_activation
  vars:
    eda_rulebook_activations:
      - name: Github Hook 5
        description: Hook to listen for changes in GitHub
        project: EDA_example
        rulebook: git-hook-deploy-rules.yml
        decision_environment: Automation Hub Default Decision Environment
        extra_vars:
          provider: github-local
          repo_url: https://github.com/ansible/ansible-rulebook.git
        enabled: false
```
# Is there a relevant Issue open for this?
resolves #10 
resolves #11 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
