### PR TITLE
Add user token

### DIFF
--- a/changelogs/fragments/user_token.yml
+++ b/changelogs/fragments/user_token.yml
@@ -3,4 +3,3 @@
       - Added user_token module
       - Added user_token role
     ...
-

--- a/changelogs/fragments/user_token.yml
+++ b/changelogs/fragments/user_token.yml
@@ -3,4 +3,4 @@
       - Added user_token module
       - Added user_token role
     ...
-    
+

--- a/changelogs/fragments/user_token.yml
+++ b/changelogs/fragments/user_token.yml
@@ -1,0 +1,6 @@
+---
+    major_changes:
+      - Added user_token module
+      - Added user_token role
+    ...
+    

--- a/plugins/module_utils/eda_module.py
+++ b/plugins/module_utils/eda_module.py
@@ -486,6 +486,7 @@ class EDAModule(AnsibleModule):
         auto_exit=True,
         item_type="unknown",
         associations=None,
+        treat_conflict_as_unchanged=False,
     ):
 
         # This will exit from the module on its own
@@ -526,6 +527,8 @@ class EDAModule(AnsibleModule):
                         new_item["name"],
                     )
                 self.json_output["changed"] = True
+            elif response["status_code"] in [409] and treat_conflict_as_unchanged:
+                self.json_output["changed"] = False
             else:
                 if "json" in response and "__all__" in response["json"]:
                     self.fail_json(msg="Unable to create {0} {1}: {2}".format(item_type, item_name, response["json"]["__all__"][0]))

--- a/plugins/modules/user_token.py
+++ b/plugins/modules/user_token.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2024, Derek Waters <@derekwaters>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = """
+---
+module: user_token
+author: "Derek Waters (@derekwaters)"
+short_description: Manage the user tokens of the current user in EDA Controller
+description:
+    - Create, update and delete user tokens in EDA Controller
+options:
+    name:
+      description:
+        - The name of the token.
+      required: True
+      type: str
+    new_name:
+      description:
+        - Setting this option will change the existing name (looked up via the name field).
+      type: str
+    description:
+      description:
+        - The description of the token.
+      required: False
+      type: str
+    token:
+      description:
+        - The token data to set for the user.
+      required: True
+      type: str
+
+extends_documentation_fragment: infra.eda_configuration.auth
+"""
+
+
+EXAMPLES = """
+- name: Create eda user token
+  infra.eda_configuration.user_token:
+    name: my_user_token
+    description: my user token for accessing AAP
+    token: SOMETOKENDATA
+    eda_host: eda.example.com
+    eda_username: admin
+    eda_password: Sup3r53cr3t
+
+"""
+
+from ..module_utils.eda_module import EDAModule
+
+
+def main():
+    # Any additional arguments that are not fields of the item can be added here
+    argument_spec = dict(
+        name=dict(required=True),
+        new_name=dict(),
+        description=dict(),
+        token=dict(required=True, no_log=True),
+    )
+
+    # Create a module for ourselves
+    module = EDAModule(argument_spec=argument_spec)
+
+    # Extract our parameters
+    name = module.params.get("name")
+    new_name = module.params.get("new_name")
+
+    new_fields = {}
+
+    # There is no way (that I can find) to search for an existing token
+    # based on name. This module can only attempt to create new tokens
+    # and fail safe if the token already exists (there is no way to patch
+    # an existing token)
+
+    # Create the data that gets sent for create and update
+    # Remove these two comments for final
+    # Check that Links and groups works with this.
+    new_fields["name"] = new_name if new_name else name
+    for field_name in (
+        "description",
+        "token",
+    ):
+        field_val = module.params.get(field_name)
+        if field_val is not None:
+            new_fields[field_name] = field_val
+
+    module.create_if_needed(
+        None,
+        new_fields,
+        endpoint="users/me/awx-tokens",
+        item_type="awx-tokens",
+        treat_conflict_as_unchanged=True
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/user_token/README.md
+++ b/roles/user_token/README.md
@@ -1,0 +1,101 @@
+# infra.eda_configuration.user_token
+
+## Description
+
+An Ansible Role to create User Tokens in EDA Controller. Note that tokens may only be applied to the user account accessing the API (ie. eda_username)
+Note that tokens cannot be updated, only created.
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---:|:---:|:---:|:---:|:---:|
+|`eda_host`|""|yes|URL to the EDA Controller (alias: `eda_hostname`)|127.0.0.1|
+|`eda_username`|""|yes|Admin User on the EDA Controller ||
+|`eda_password`|""|yes|EDA Controller Admin User's password on the EDA Controller Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
+|`eda_validate_certs`|`False`|no|Whether or not to validate the Ansible EDA Controller Server's SSL certificate.||
+|`eda_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the EDA Controller host.||
+|`eda_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
+|`eda_user_tokens`|`see below`|yes|Data structure describing your user tokens, described below.||
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to False as normally the add project task does not include sensitive information.
+eda_configuration_user_token_secure_logging defaults to the value of eda_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of EDA Controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_user_token_secure_logging`|`False`|no|Whether or not to include the sensitive Project role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`eda_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`eda_configuration_user_token_async_retries`|`eda_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`eda_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`eda_configuration_user_token_async_delay`|`eda_configuration_async_delay`|no|This sets the delay between retries for the role.|
+
+## Data Structure
+
+### User Token Variables
+
+|Variable Name|Default Value|Required|Type|Description|
+|:---:|:---:|:---:|:---:|:---:|
+|`name`|""|yes|str|User Token name. Must be lower case containing only alphanumeric characters and underscores.|
+|`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.)|
+|`description`|""|yes|str|Description to use for the Project.|
+|`token`|""|yes|str|The value of the token to associate with the user.|
+
+### Standard User Token Data Structure
+
+#### Yaml Example
+
+```yaml
+---
+eda_user_tokens:
+  - name: my_default_token
+    description: my default user token
+    token: TOKEN_VALUE
+```
+
+## Playbook Examples
+
+### Standard Role Usage
+
+```yaml
+---
+- name: Add user token to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # eda_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - ../../user_token
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/eda_configuration#licensing)
+
+## Author
+
+[Derek Waters](https://github.com/derekwaters/)

--- a/roles/user_token/defaults/main.yml
+++ b/roles/user_token/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+eda_user_tokens: []
+
+eda_configuration_user_token_secure_logging: "{{ eda_configuration_secure_logging | default(false) }}"
+eda_configuration_user_token_async_retries: "{{ eda_configuration_async_retries | default(50) }}"
+eda_configuration_user_token_async_delay: "{{ eda_configuration_async_delay | default(1) }}"
+eda_configuration_async_dir: null
+...

--- a/roles/user_token/meta/argument_specs.yml
+++ b/roles/user_token/meta/argument_specs.yml
@@ -1,0 +1,70 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create user tokens in EDA controller.
+    options:
+      eda_user_tokens:
+        default: []
+        required: false
+        description: Data structure describing your user tokens to manage.
+        type: list
+        elements: dict
+
+      # Async variables
+      eda_configuration_user_token_async_retries:
+        default: "{{ eda_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      eda_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      eda_configuration_user_token_async_delay:
+        default: "{{ eda_configuration_async_delay | default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      eda_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      eda_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      eda_configuration_user_token_secure_logging:
+        default: "{{ eda_configuration_secure_logging | default(false) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive role tasks in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      eda_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      eda_host:
+        required: false
+        description: URL to the EDA Controller Server.
+        type: str
+      eda_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the EDA Controller Server's SSL certificate.
+        type: str
+      eda_request_timeout:
+        default: 10
+        required: false
+        description: Specify the timeout Ansible should use in requests to the EDA Controller host.
+        type: float
+      eda_username:
+        required: false
+        description: User for authentication on EDA Controller
+        type: str
+      eda_password:
+        required: false
+        description: User's password For EDA Controller
+        type: str
+...

--- a/roles/user_token/meta/main.yml
+++ b/roles/user_token/meta/main.yml
@@ -1,0 +1,42 @@
+---
+galaxy_info:
+  role_name: "user_token"
+  author: "Derek Waters"
+  description: "An Ansible Role to create a user token in EDA Controller."
+  company: "Red Hat"
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: "GPLv3+"
+
+  min_ansible_version: "2.9"
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  platforms:
+    - name: "EL"
+      versions:
+        - "all"
+
+  galaxy_tags:
+    - "edacontroller"
+    - "eda"
+    - "configuration"
+    - "user"
+    - "users"
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+...

--- a/roles/user_token/tasks/main.yml
+++ b/roles/user_token/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+
+# Create EDA Controller User Tokens
+- name: Add EDA Controller user token
+  user_token:
+    name:             "{{ __token_item.name }}"
+    new_name:         "{{ __token_item.new_name | default(omit) }}"
+    description:      "{{ __token_item.description | default(omit) }}"
+    token:            "{{ __token_item.token | default(omit) }}"
+    eda_host:         "{{ eda_host | default(eda_hostname) }}"
+    eda_username:     "{{ eda_username | default(omit) }}"
+    eda_password:     "{{ eda_password | default(omit) }}"
+    validate_certs:   "{{ eda_validate_certs | default(omit) }}"
+    request_timeout:  "{{ eda_request_timeout | default(omit) }}"
+  loop: "{{ eda_user_tokens }}"
+  loop_control:
+    loop_var: "__token_item"
+  no_log: "{{ eda_configuration_user_token_secure_logging }}"
+  async: 1000
+  poll: 0
+  register: __user_tokens_job_async
+  changed_when: not __user_tokens_job_async.changed
+  vars:
+    ansible_async_dir: '{{ eda_configuration_async_dir }}'
+
+- name: "Create user_token | Wait for finish the user_token creation"
+  ansible.builtin.async_status:
+    jid: "{{ __user_tokens_job_async_result_item.ansible_job_id }}"
+  register: __user_tokens_job_async_result
+  until: __user_tokens_job_async_result.finished
+  retries: "{{ eda_configuration_user_token_async_retries }}"
+  delay: "{{ eda_configuration_user_token_async_delay }}"
+  loop: "{{ __user_tokens_job_async.results }}"
+  loop_control:
+    loop_var: __user_tokens_job_async_result_item
+  when: __user_tokens_job_async_result_item.ansible_job_id is defined
+  no_log: "{{ eda_configuration_user_token_secure_logging }}"
+  vars:
+    ansible_async_dir: '{{ eda_configuration_async_dir }}'
+...

--- a/roles/user_token/tests/test.yml
+++ b/roles/user_token/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add user token to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # eda_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - ../../user_token
+...

--- a/roles/user_token/tests/vars/user_tokens.yml
+++ b/roles/user_token/tests/vars/user_tokens.yml
@@ -1,0 +1,6 @@
+---
+eda_user_tokens:
+  - name: my_user_token
+    description: my awesome token
+    token: ABCDEF
+...

--- a/tests/playbooks/eda_configs/eda_user_tokens.yml
+++ b/tests/playbooks/eda_configs/eda_user_tokens.yml
@@ -4,4 +4,4 @@ eda_user_tokens:
     description: my awesome token
     token: ABCDEF
 ...
-    
+

--- a/tests/playbooks/eda_configs/eda_user_tokens.yml
+++ b/tests/playbooks/eda_configs/eda_user_tokens.yml
@@ -1,0 +1,7 @@
+---
+eda_user_tokens:
+  - name: my_user_token
+    description: my awesome token
+    token: ABCDEF
+...
+    

--- a/tests/playbooks/eda_configs/eda_user_tokens.yml
+++ b/tests/playbooks/eda_configs/eda_user_tokens.yml
@@ -4,4 +4,3 @@ eda_user_tokens:
     description: my awesome token
     token: ABCDEF
 ...
-

--- a/tests/playbooks/testing_collections_playbook.yml
+++ b/tests/playbooks/testing_collections_playbook.yml
@@ -43,4 +43,8 @@
     - name: Create rulebook activations
       ansible.builtin.include_role:
         name: decision_environment
+
+    - name: Create user tokens
+      ansible.builtin.include_role:
+        name: user_token
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR implements a module and role allowing for the creation of AWX/AAP access tokens in EDA. Tokens can only be created for the user accessing the EDA API via the role. Note that the API does not allow for searching for a token by name, or of updating tokens. The only way to detect that a token with a given name exists is to try and create it, and detect a HTTP 409 error.

# How should this be tested?

Automated test included in the testing_collections_playbook.yml file

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

No other relevant PRs. 
