### PR TITLE
Fix issue where project sync reports fail because it is already running

### DIFF
--- a/changelogs/fragments/proj_sync.yml
+++ b/changelogs/fragments/proj_sync.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixes issue where project sync reports fail because it is already running
+...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fix issue where project sync reports fail because it is already running
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI will work
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #43 

# Other Relevant info, PRs, etc
See job failure from before: https://github.com/redhat-cop/eda_configuration/actions/runs/8662825246/job/23755928925#step:12:93
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
