### PR TITLE
Adds tls_validation option to project module and role

### DIFF
--- a/changelogs/fragments/project-api.yml
+++ b/changelogs/fragments/project-api.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Adds tls_validation option to project module and role
+...

--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -44,6 +44,11 @@ options:
       required: True
       type: str
       aliases: ['scm_url']
+    tls_validation:
+      description:
+        - Whether to use TLS validation against the url.
+      type: bool
+      default: True
     credential:
       description:
         - The token needed to utilize the SCM URL.
@@ -84,6 +89,7 @@ def main():
         new_name=dict(),
         description=dict(),
         url=dict(required=True, aliases=["scm_url"]),
+        tls_validation=dict(type="bool", default=True),
         credential=dict(),
         state=dict(choices=["present", "absent"], default="present"),
     )
@@ -112,6 +118,7 @@ def main():
     for field_name in (
         "description",
         "url",
+        "tls_validation",
     ):
         field_val = module.params.get(field_name)
         if field_val is not None:

--- a/roles/project/README.md
+++ b/roles/project/README.md
@@ -52,7 +52,7 @@ This also speeds up the overall role.
 |`new_name`|""|no|str|Setting this option will change the existing name (looked up via the name field.)|
 |`description`|""|no|str|Description to use for the Project.|
 |`url`|""|yes|str|A URL to a remote archive, such as a Github Release or a build artifact stored in Artifactory and unpacks it into the project path for use. (Alias: scm_url)|
-|`tls_validation`|""|no|bool|Whether the URL should validate using TLS.|
+|`tls_validation`|true|no|bool|Whether the URL should validate using TLS.|
 |`credential`|""|no|str|The token needed to utilize the SCM URL.|
 |`state`|`present`|no|str|Desired state of the project.|
 

--- a/roles/project/README.md
+++ b/roles/project/README.md
@@ -52,6 +52,7 @@ This also speeds up the overall role.
 |`new_name`|""|no|str|Setting this option will change the existing name (looked up via the name field.)|
 |`description`|""|no|str|Description to use for the Project.|
 |`url`|""|yes|str|A URL to a remote archive, such as a Github Release or a build artifact stored in Artifactory and unpacks it into the project path for use. (Alias: scm_url)|
+|`tls_validation`|""|no|bool|Whether the URL should validate using TLS.|
 |`credential`|""|no|str|The token needed to utilize the SCM URL.|
 |`state`|`present`|no|str|Desired state of the project.|
 
@@ -65,6 +66,7 @@ eda_projects:
   - name: my_project
     description: my awesome project
     url: https://github.com/ansible/ansible-rulebook.git
+    tls_validation: true
     credential: test_token
 ```
 

--- a/roles/project/tasks/main.yml
+++ b/roles/project/tasks/main.yml
@@ -7,6 +7,7 @@
     new_name:         "{{ __project_item.new_name | default(omit) }}"
     description:      "{{ __project_item.description | default(omit) }}"
     url:              "{{ __project_item.url | default(__project_item.scm_url | default(omit)) }}"
+    tls_validation:   "{{ __project_item.tls_validation | default(omit) }}"
     credential:       "{{ __project_item.credential | default(omit) }}"
     state:            "{{ __project_item.state | default(eda_state | default('present')) }}"
     eda_host:         "{{ eda_host | default(eda_hostname) }}"

--- a/roles/project/tests/vars/projects.yml
+++ b/roles/project/tests/vars/projects.yml
@@ -3,5 +3,6 @@ eda_projects:
   - name: my_project
     description: my awesome project
     url: https://github.com/ansible/ansible-rulebook.git
+    tls_validation: true
     credential: test_token
 ...

--- a/tests/playbooks/eda_configs/eda_projects.yml
+++ b/tests/playbooks/eda_configs/eda_projects.yml
@@ -6,6 +6,7 @@ eda_projects:
     sync: true
     wait: true
     timeout: 30
+    tls_validation: false
   - name: my_project_clone
     description: my awesome project clone
     url: https://github.com/ansible/event-driven-ansible.git


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Adds a missing `tls_validation` option to the project module and role. I've also validated there are currently no mossing API options for other roles (latest AAP 2.4 version)

# How should this be tested?
CI is updated
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #47 

# Other Relevant info, PRs, etc
CI currently broken. #49 will fix it and could be merged first so it can be run through for this PR
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
