### PR TITLE
Pin CI to a specific commit rather than using devel

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         eda_server_version:
-          - main
+          - 93ef155accc3013f82a4870569638e7e1eaf2adc
     uses: "./.github/workflows/ci_standalone_versioned.yml"
     with:
       eda_server_version: ${{ matrix.eda_server_version }}

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         eda_server_version:
+          # Pinning to specific ref because of breaking changes to user endpoint after this. This will need to be recified later.
           - 93ef155accc3013f82a4870569638e7e1eaf2adc
     uses: "./.github/workflows/ci_standalone_versioned.yml"
     with:

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -14,6 +14,9 @@ on:
         default: devel
         type: string
 
+env:
+  EDA_IMAGE: quay.io/ansible/eda-server:sha-${{ inputs.eda_server_version }}  # If we transfer back to branches/tags then this needs updating to match the branch
+
 jobs:
 
   integration:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Pins CI to a specific version of eda-server.

The users/roles endpoints have changed meaning there will be work to do around this (I'm guessing it'll make it into EDA2.5) so we will need to overhaul that (Seems there are teams and orgs introduced). 

In future, because there are no specific releases on eda-server, we may need to keep this idea of using a GH ref rather than a tag or branch. I think this means we will be able to test multiple versions as well as I worked out how to get a different image rather than the one from main.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Ci works on my fork: https://github.com/Tompage1994/eda_configuration/actions/runs/8783017306/job/24098314493
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
