### PR TITLE
Fix restart_policy on-failure

### DIFF
--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -53,7 +53,7 @@ options:
       description:
         - The policy used to determine whether to restart a rulebook.
       required: False
-      choices: ["always", "never", "on_failure"]
+      choices: ["always", "never", "on-failure"]
       default: "always"
       type: str
     extra_vars:
@@ -120,7 +120,7 @@ def main():
         project=dict(),
         rulebook=dict(required=True),
         decision_environment=dict(required=True),
-        restart_policy=dict(choices=["always", "never", "on_failure"], default="always"),
+        restart_policy=dict(choices=["always", "never", "on-failure"], default="always"),
         extra_vars=dict(type="dict"),
         enabled=dict(type="bool", default="true"),
         state=dict(choices=["present", "absent", "restarted"], default="present"),

--- a/roles/rulebook_activation/README.md
+++ b/roles/rulebook_activation/README.md
@@ -53,7 +53,7 @@ This also speeds up the overall role.
 |`project`|""|no|str|Project to use for the Activation.|
 |`rulebook`|""|yes|str|rulebook to use for the Activation.|
 |`decision_environment`|""|yes|str|Decision_environment to use for the Activation.|
-|`restart_policy`|"always"|no|str|Restart_policy to use for the Activation, choice of ["always", "never", "on_failure"]|
+|`restart_policy`|"always"|no|str|Restart_policy to use for the Activation, choice of ["always", "never", "on-failure"]|
 |`extra_vars`|""|no|str|Extra_vars to use for the Activation.|
 |`awx_token`|""|no|str|The token used to authenticate to controller.|
 |`enabled`|"true"|no|str|Whether the rulebook activation is automatically enabled to run.|


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
There is a bug in the code. EDA API expects restart_policy to be on-failure, not on_failure. This broke my systems.

This is what EDA gives from API:

```
restart_policy	RestartPolicyEnumstring

    always - always
    on-failure - on-failure
    never - never
``` 
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

create simple config for rulebook activation, and use on-failure and on_failure. The latter one fails for me:

```
---
- name: test rulebook activation
  hosts: all
  connection: local
  gather_facts: false
  tasks:
    - name: add rba - Listen to Dynatrace events
      infra.eda_configuration.rulebook_activation:
        awx_token: aap
        eda_host: https://eda-controller-aap.apps.cluster-aap.sandbox3026.opentlc.com
        eda_password: xxx
        eda_username: admin
        # eda_validate_certs: false
        name: Listen to Dynatrace events
        decision_environment: de-for-dynatrace
        description: Listen to Dynatrace events
        enabled: true
        project: OpenShift Event Rulebooks
        restart_policy: on_failure
        rulebook: dynatrace_event.yml

```
# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

I didn't create an issue yet

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
I run into this while building env for RH summit 2024.  EDA API is /api/eda/v1/openapi.json. Need to check if this is the latest before applying PR